### PR TITLE
Incorrect access token should not be allowed #64

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -79,6 +79,11 @@ const getData = function getData() {
 };
 
 if (window.localStorage) {
+    if (!localStorage.getItem('usernames')) {
+        localStorage.setItem('usernames', JSON.stringify(DEFAULTUSERNAMES));
+    }
+    USERNAMES = JSON.parse(localStorage.getItem('usernames'));
+
     if (!localStorage.getItem('accessToken')) {
         swal({
             title: 'Submit Github Token',
@@ -93,8 +98,15 @@ if (window.localStorage) {
                         if (token === '') {
                             reject('Enter Valid Token');
                         } else {
-                            localStorage.setItem('accessToken', token);
-                            resolve();
+                            const url = `https://api.github.com/?access_token=${token}`;
+                            axios({
+                                url,
+                                method: 'get',
+                                responseType: 'json',
+                            }).then(() => {
+                                localStorage.setItem('accessToken', token);
+                                resolve();
+                            }).catch(() => reject('Error: invalid token'));
                         }
                     }, 1000);
                 });
@@ -118,10 +130,6 @@ if (window.localStorage) {
 accessToken = localStorage.getItem('accessToken');
 
 if (accessToken) {
-    if (!localStorage.getItem('usernames')) {
-        localStorage.setItem('usernames', JSON.stringify(DEFAULTUSERNAMES));
-    }
-    USERNAMES = JSON.parse(localStorage.getItem('usernames'));
     getData();
     renderLanguageSelector();
     renderUsernames();


### PR DESCRIPTION
Here is a fix for the problem from issue #64

I have also moved USERS definition up. Because it was done only after the access token was defined and adding extra call to github API caused an error - USERS were not defined since it was not passing the if statement. This occured only at the first time after giving the access token, after refresh it already had access token and thus USERS.

@mubaris 